### PR TITLE
objects: the example photographs itself, and a bad mesh path is heard headless

### DIFF
--- a/crates/balaur_render/src/mesh.rs
+++ b/crates/balaur_render/src/mesh.rs
@@ -100,12 +100,14 @@ pub(crate) fn register_mesh_component(reg: &mut Registry<'_>) {
                         .to_string()
                 };
                 let source = text(k::SOURCE);
-                // Warned, not refused: one unreadable model must not take the
-                // whole scene down, and the node still has a place in the tree.
+                // Warned, not refused, and resolved the whole way: one bad model
+                // must not take the scene down, and a headless run should hear of it.
                 if !source.is_empty()
-                    && let Err(why) = balaur_core::assets::load_typed::<MeshData>(eng, &source) {
-                        tracing::warn!("mesh '{source}': {why:#}");
-                    }
+                    && let Err(why) = balaur_core::assets::load_typed::<MeshData>(eng, &source)
+                        .and_then(|definition| balaur_core::mesh::load_from(eng, &definition))
+                {
+                    tracing::warn!("mesh '{source}': {why:#}");
+                }
                 crate::set_mesh(eng, entity, source.clone(), text(k::SKELETON), text(k::TEXTURE))?;
                 set_morph_weights(eng, entity, &source, params);
                 crate::material::set_material_3d(eng, entity, &text("material"))

--- a/examples/objects/scenes/main.toml
+++ b/examples/objects/scenes/main.toml
@@ -1,5 +1,5 @@
-# Every object the engine builds, one row per category along -z: primitives,
-# paths, booleans, cloners, then a word and colour per vertex.
+# Every object the engine builds, one row per category twelve units apart
+# along -z: primitives, paths, booleans, cloners, then a word and paint.
 
 [[assets]]
 id = "ring"
@@ -60,7 +60,7 @@ points = [
   [0.16, 0.0], [0.16, 0.09], [0.09, 0.16], [0.0, 0.16],
   [-0.09, 0.16], [-0.16, 0.09], [-0.16, 0.0],
   [-0.16, -0.09], [-0.09, -0.16], [0.0, -0.16],
-  [0.09, -0.16], [0.16, -0.09], [0.16, 0.0],
+  [0.09, -0.16], [0.16, -0.09],
 ]
 
 [[assets]]
@@ -110,11 +110,11 @@ look_at = [0.0, 1.0, 0.0]
 id = "n_ground"
 name = "Ground"
 parent = "n_world"
-position = [0, -0.02, -12]
+position = [0, -0.02, -24]
 
 [nodes.shape3d]
 kind = "plane"
-half_extents = [10, 0, 16]
+half_extents = [10, 0, 30]
 segments = 8
 color = [0.22, 0.24, 0.27, 1]
 
@@ -185,7 +185,7 @@ color = [0.75, 0.75, 0.78, 1]
 id = "n_arch"
 name = "Arch"
 parent = "n_world"
-position = [-3.2, 0, -6]
+position = [-3.2, 0, -12]
 
 [nodes.mesh]
 source = "#arch"
@@ -194,7 +194,7 @@ source = "#arch"
 id = "n_goblet"
 name = "Goblet"
 parent = "n_world"
-position = [0, 0, -6]
+position = [0, 0, -12]
 
 [nodes.mesh]
 source = "#goblet"
@@ -203,7 +203,7 @@ source = "#goblet"
 id = "n_handrail"
 name = "Handrail"
 parent = "n_world"
-position = [3.4, 0, -6]
+position = [3.4, 0, -12]
 
 [nodes.mesh]
 source = "#handrail"
@@ -212,7 +212,7 @@ source = "#handrail"
 id = "n_union"
 name = "Union"
 parent = "n_world"
-position = [-3.5, 1, -12]
+position = [-3.5, 1, -24]
 
 [nodes.boolean3d]
 op = "union"
@@ -224,23 +224,23 @@ parent = "n_union"
 
 [nodes.shape3d]
 kind = "cuboid"
-half_extents = [0.6, 0.6, 0.6]
+half_extents = [0.7, 0.7, 0.7]
 
 [[nodes]]
 id = "n_union_b"
 name = "B"
 parent = "n_union"
-position = [0.5, 0.5, 0.5]
+position = [0.55, 0.55, 0.55]
 
 [nodes.shape3d]
 kind = "ball"
-radius = 0.7
+radius = 0.5
 
 [[nodes]]
 id = "n_difference"
 name = "Difference"
 parent = "n_world"
-position = [0, 1, -12]
+position = [0, 1, -24]
 
 [nodes.boolean3d]
 op = "difference"
@@ -258,17 +258,17 @@ half_extents = [0.7, 0.7, 0.7]
 id = "n_difference_b"
 name = "B"
 parent = "n_difference"
-position = [0.45, 0.45, 0.45]
+position = [0.6, 0.6, 0.6]
 
 [nodes.shape3d]
 kind = "ball"
-radius = 0.75
+radius = 0.55
 
 [[nodes]]
 id = "n_intersection"
 name = "Intersection"
 parent = "n_world"
-position = [3.5, 1, -12]
+position = [3.5, 1, -24]
 
 [nodes.boolean3d]
 op = "intersection"
@@ -295,7 +295,7 @@ radius = 0.9
 id = "n_row"
 name = "Row"
 parent = "n_world"
-position = [-4.5, 0.4, -18]
+position = [-5.6, 0.4, -36]
 
 [nodes.cloner]
 mode = "linear"
@@ -318,7 +318,7 @@ color = [0.7, 0.6, 0.4, 1]
 id = "n_ring_of"
 name = "Ring"
 parent = "n_world"
-position = [0.5, 0.4, -18]
+position = [0.6, 0.4, -36]
 
 [nodes.cloner]
 mode = "radial"
@@ -341,7 +341,7 @@ color = [0.5, 0.65, 0.75, 1]
 id = "n_field"
 name = "Field"
 parent = "n_world"
-position = [4.0, 0.3, -19]
+position = [4.0, 0.3, -37]
 
 [nodes.cloner]
 mode = "grid"
@@ -365,7 +365,7 @@ color = [0.45, 0.7, 0.4, 1]
 id = "n_title"
 name = "Title"
 parent = "n_world"
-position = [-2.6, 0.9, -24]
+position = [-2.6, 0.9, -48]
 
 [nodes.mesh]
 source = "#title"
@@ -374,7 +374,7 @@ source = "#title"
 id = "n_painted"
 name = "Painted"
 parent = "n_world"
-position = [2.4, 0.2, -24]
+position = [2.4, 0.2, -48]
 script = "scripts/breathe.rn"
 
 [nodes.mesh]

--- a/examples/objects/scripts/tour.rn
+++ b/examples/objects/scripts/tour.rn
@@ -1,28 +1,57 @@
-// Walks the camera down the rows and names the one it has reached. Every
-// row is one category of them, laid out along -z.
+// Walks the camera down the rows and, when asked, photographs each one.
+// `balaur run examples/objects -- shots=<dir>` writes one PNG per pose there,
+// which is how the website's pictures of this example are made.
 
-const ROWS = [
-    #{ z: 0.0, name: "primitives" },
-    #{ z: -6.0, name: "paths: extruded, revolved, swept" },
-    #{ z: -12.0, name: "booleans: union, difference, intersection" },
-    #{ z: -18.0, name: "cloner: linear, radial, scattered grid" },
-    #{ z: -24.0, name: "a word as a mesh, and colour per vertex" },
+const POSES = [
+    #{ slug: "overview", eye: [0.0, 16.0, 18.0], at: [0.0, 0.5, -16.0] },
+    #{ slug: "primitives", eye: [0.0, 3.6, 10.0], at: [0.0, 0.8, 0.0] },
+    #{ slug: "paths", eye: [0.0, 3.6, -2.0], at: [0.0, 0.9, -12.0] },
+    #{ slug: "booleans", eye: [0.0, 3.6, -14.0], at: [0.0, 0.9, -24.0] },
+    #{ slug: "cloner", eye: [1.0, 3.6, -26.0], at: [1.0, 0.4, -36.0] },
+    #{ slug: "text", eye: [0.0, 3.0, -39.5], at: [0.0, 0.9, -48.0] },
 ];
 
-// How long the camera rests on a row before moving to the next.
+// Seconds the camera rests on a pose, and the frame within that rest on which
+// its picture is taken: the camera node moves as the pose starts, and a
+// screenshot saves the frame after it is asked for.
 const DWELL = 3.5;
+const SETTLE = 12;
 
 pub fn init(this) {
+    this.root = this.node.parent();
     this.clock = 0.0;
-    this.at = 0;
+    this.frame = 0;
+    this.at = -1;
+    this.shots = "";
+    for arg in engine::args() {
+        let parts = arg.split('=').collect::<Vec>();
+        if parts.len() == 2 && parts[0] == "shots" {
+            this.shots = parts[1];
+        }
+    }
+}
+
+// The camera is a node, so it is the node that moves: the camera component
+// reads its own transform every tick, and would undo a bare set_camera.
+// The scene always has one, so there is nothing to check for here.
+fn look(this, pose) {
+    let camera = this.root.get_node("Camera");
+    let e = pose.eye;
+    camera.set_position(e[0], e[1], e[2]);
+    camera.patch_component("camera", #{ look_at: pose.at });
 }
 
 pub fn update(this, dt) {
     this.clock += dt;
-    if this.clock > DWELL {
+    this.frame += 1;
+    if this.at < 0 || this.clock > DWELL {
         this.clock = 0.0;
-        this.at = (this.at + 1) % ROWS.len();
+        this.frame = 0;
+        this.at = (this.at + 1) % POSES.len();
+        look(this, POSES[this.at]);
     }
-    let row = ROWS[this.at];
-    render::set_camera(0.0, 3.0, row.z + 7.0, 0.0, 1.0, row.z);
+    if this.shots != "" && this.frame == SETTLE {
+        let pose = POSES[this.at];
+        render::screenshot(format!("{}/{}-{}.png", this.shots, this.at, pose.slug));
+    }
 }

--- a/scripts/showcase.sh
+++ b/scripts/showcase.sh
@@ -94,6 +94,25 @@ shot hello_open        examples/hello      "scene,select:World,dock:output"
 shot persona_scene     examples/angrynerds "scene,select:Bird"
 shot persona_script    examples/hello      "script,select:Spinner"
 shot persona_animate   examples/rig        "anim,select:Thigh"
+
+# The objects example photographs itself: its tour script saves one frame per
+# pose when run with `shots=`, so these come from `run` and not an editor state.
+objects_shots() {
+  wanted objects || return 0
+  printf '%-22s images ' objects
+  rm -rf examples/objects/shots
+  mkdir -p examples/objects/shots
+  balaur run examples/objects --offscreen --fixed-tick --frames 1300 -- shots=shots >"$work/objects.log" 2>&1 || true
+  local any=0 f
+  for f in examples/objects/shots/*.png; do
+    [ -f "$f" ] || continue
+    cp "$f" "$img/objects_$(basename "$f" | sed 's/^[0-9]*-//')"
+    any=1
+  done
+  rm -rf examples/objects/shots
+  if [ $any = 1 ]; then echo ok; else failed objects; fi
+}
+objects_shots
 shot persona_physics   examples/angrynerds "phys,select:Bird"
 shot persona_interface examples/angrynerds "ui,select:Restart,play"
 shot physics_overlays  examples/angrynerds "phys,select:Bird"


### PR DESCRIPTION
The tour script moves the camera node rather than calling set_camera,
which the camera component would undo every tick, and takes one frame per
pose when run with shots=. scripts/showcase.sh regenerates the website's
six pictures from that. The rows sit twelve units apart so a camera can
stand between two and see one whole, and the boolean operands are sized so
a cube stays a cube with a ball poking out of it.

The sweep's profile had thirteen control points where four closed cubics
take twelve, and only the windowed backend's upload ever noticed. The mesh
component now resolves its asset the whole way when it is applied, so a
headless run, and so e2e, report a path or a word that will not build.