### PR TITLE
ci: tell the website when a nightly is published

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -226,3 +226,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: ./scripts/draft_release.sh dist
+      # The site follows the rolling nightly; it pulls a version tag by hand.
+      - name: Tell the website
+        if: github.ref == 'refs/heads/main'
+        env:
+          GH_TOKEN: ${{ secrets.WEBSITE_DISPATCH_TOKEN }}
+        run: |
+          gh api repos/balaurengine/balaur-website/dispatches \
+            -f event_type=engine-nightly \
+            -f "client_payload[version]=$(cat dist/VERSION)"


### PR DESCRIPTION
After the rolling nightly is drafted from main, the release job sends the
website repository an engine-nightly event carrying the build's VERSION,
and the site's deploy pulls that nightly into static/play the way a manual
run does. It needs one secret on this repository, WEBSITE_DISPATCH_TOKEN,
a token allowed to write contents on balaurengine/balaur-website.